### PR TITLE
Listener node warns about parsing errors

### DIFF
--- a/dwm1001_driver/listener_node.py
+++ b/dwm1001_driver/listener_node.py
@@ -63,7 +63,11 @@ class ListenerNode(Node):
         self.declare_parameter("serial_port", "", serial_port_descriptor)
 
     def timer_callback(self):
-        tag_id, tag_position = self.dwm_handle.wait_for_position_report()
+        try:
+            tag_id, tag_position = self.dwm_handle.wait_for_position_report()
+        except dwm1001.ParsingError as error:
+            self.get_logger().warn("Could not parse position report. Skipping it.")
+            return
 
         msg = TagPosition()
         msg.tag_id = tag_id


### PR DESCRIPTION
The Listener node now issues a warning when the current position report cannot be properly parsed. The node skips that report instead of crashing.

Closes #4