### PR TITLE
Add dummy listener node

### DIFF
--- a/dwm1001_driver/dwm1001_driver/dummy_listener_node.py
+++ b/dwm1001_driver/dwm1001_driver/dummy_listener_node.py
@@ -1,0 +1,72 @@
+# Copyright 2023 The Human and Intelligent Vehicle Ensembles (HIVE) Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+from dwm1001_interfaces.msg import TagPosition
+
+
+class DummyListenerNode(Node):
+    def __init__(self) -> None:
+        super().__init__("dummy_listener")
+
+        self._declare_parameters()
+
+        self.tag_id = self.get_parameter("tag_id").value
+        if not self.tag_id:
+            self._shutdown_fatal("No DWM1001 tag identifier specified.")
+
+        self.get_logger().info("Started position reporting.")
+
+        self.publisher = self.create_publisher(TagPosition, "tag_position", 1)
+        self.timer = self.create_timer(1 / 10, self.timer_callback)
+
+    def _shutdown_fatal(self, message: str) -> None:
+        self.get_logger().fatal(message + " Shutting down.")
+        exit()
+
+    def _declare_parameters(self):
+        tag_id = ParameterDescriptor(
+            description="DWM1001 tag identifier",
+            type=ParameterType.PARAMETER_STRING,
+            read_only=True,
+        )
+
+        self.declare_parameter("tag_id", "", tag_id)
+
+    def timer_callback(self):
+        msg = TagPosition()
+        msg.tag_id = self.tag_id
+        msg.position.x = 1.2
+        msg.position.y = 2.3
+        msg.position.z = 3.4
+        msg.quality = 42
+
+        self.publisher.publish(msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    dummy_listener = DummyListenerNode()
+    rclpy.spin(dummy_listener)
+
+    dummy_listener.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/dwm1001_driver/setup.py
+++ b/dwm1001_driver/setup.py
@@ -17,5 +17,10 @@ setup(
     description="ROS 2 driver package for Qorvo (previously Decawave) DWM1001",
     license="Apache License 2.0",
     tests_require=["pytest"],
-    entry_points={"console_scripts": ["listener = dwm1001_driver.listener_node:main"]},
+    entry_points={
+        "console_scripts": [
+            "listener = dwm1001_driver.listener_node:main",
+            "dummy_listener = dwm1001_dummy_driver.dummy_listener_node:main",
+        ]
+    },
 )


### PR DESCRIPTION
This node publishes hard-coded TagPosition messages. It will be made more robust in the future as needed.

Closes #9 