### PR TITLE
Add ROS 2 Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,34 @@
+FROM mcr.microsoft.com/devcontainers/cpp:ubuntu-22.04
+
+ARG USERNAME=vscode
+
+# Set up ROS 2 repository
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+        -o /usr/share/keyrings/ros-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+        | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# Set up environment variables
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV ROS_DISTRO humble
+
+# Install ROS 2 and colcon
+RUN apt update \
+    && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+        ros-humble-ros-core=0.10.0-1* \
+        ros-humble-ament-cmake-clang-tidy \
+        ros-humble-ament-cmake-clang-format \
+        python3-colcon-common-extensions \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up ROS 2 overlay sourcing for terminal
+RUN echo 'source /opt/ros/humble/setup.bash' >> /home/${USERNAME}/.bashrc
+
+# Install common dependencies
+RUN apt update \
+    && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+        bash-completion \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /workspace/src && chown -R ${USERNAME}:${USERNAME} /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "ROS 2 Humble",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools-extension-pack",
+                "ms-vscode.cmake-tools",
+                "streetsidesoftware.code-spell-checker",
+                "ms-python.python"
+            ]
+        }
+    },
+    "remoteUser": "vscode",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/src,type=bind",
+    "workspaceFolder": "/workspace/src"
+}


### PR DESCRIPTION
The Dev Container is based off the VS Code C++ Dev Container and installs ROS 2 Humble from source.

Closes #11 