### PR TITLE
Update listener node publishers

### DIFF
--- a/dwm1001_driver/dwm1001_driver/dummy_listener_node.py
+++ b/dwm1001_driver/dwm1001_driver/dummy_listener_node.py
@@ -16,7 +16,7 @@ import rclpy
 from rclpy.node import Node
 
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
-from dwm1001_interfaces.msg import TagPosition
+from geometry_msgs.msg import PointStamped
 
 
 class DummyListenerNode(Node):
@@ -31,7 +31,7 @@ class DummyListenerNode(Node):
 
         self.get_logger().info("Started position reporting.")
 
-        self.publisher = self.create_publisher(TagPosition, "tag_position", 1)
+        self.publisher = self.create_publisher(PointStamped, "tag_position", 1)
         self.timer = self.create_timer(1 / 10, self.timer_callback)
 
     def _shutdown_fatal(self, message: str) -> None:
@@ -48,12 +48,14 @@ class DummyListenerNode(Node):
         self.declare_parameter("tag_id", "", tag_id)
 
     def timer_callback(self):
-        msg = TagPosition()
-        msg.tag_id = self.tag_id
-        msg.position.x = 1.2
-        msg.position.y = 2.3
-        msg.position.z = 3.4
-        msg.quality = 42
+        msg = PointStamped()
+
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self.tag_id
+
+        msg.point.x = 1.2
+        msg.point.y = 2.3
+        msg.point.z = 3.4
 
         self.publisher.publish(msg)
 

--- a/dwm1001_driver/dwm1001_driver/listener_node.py
+++ b/dwm1001_driver/dwm1001_driver/listener_node.py
@@ -16,7 +16,7 @@ import rclpy
 from rclpy.node import Node
 
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
-from dwm1001_interfaces.msg import TagPosition
+from geometry_msgs.msg import PointStamped
 
 import dwm1001
 import serial
@@ -34,7 +34,7 @@ class ListenerNode(Node):
         self.dwm_handle.start_position_reporting()
         self.get_logger().info("Started position reporting.")
 
-        self.publisher = self.create_publisher(TagPosition, "tag_position", 1)
+        self.publisher = self.create_publisher(PointStamped, "tag_position", 1)
         self.timer = self.create_timer(1 / 10, self.timer_callback)
 
     def _open_serial_port(self, serial_port: str) -> serial.Serial:
@@ -69,12 +69,14 @@ class ListenerNode(Node):
             self.get_logger().warn("Could not parse position report. Skipping it.")
             return
 
-        msg = TagPosition()
-        msg.tag_id = tag_id
-        msg.position.x = tag_position.x_m
-        msg.position.y = tag_position.y_m
-        msg.position.z = tag_position.z_m
-        msg.quality = tag_position.quality
+        msg = PointStamped()
+
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = tag_id
+
+        msg.point.x = tag_position.x_m
+        msg.point.y = tag_position.y_m
+        msg.point.z = tag_position.z_m
 
         self.publisher.publish(msg)
 

--- a/dwm1001_driver/package.xml
+++ b/dwm1001_driver/package.xml
@@ -12,8 +12,6 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
-  <depend>dwm1001_interfaces</depend>
-
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/dwm1001_driver/setup.py
+++ b/dwm1001_driver/setup.py
@@ -20,7 +20,7 @@ setup(
     entry_points={
         "console_scripts": [
             "listener = dwm1001_driver.listener_node:main",
-            "dummy_listener = dwm1001_dummy_driver.dummy_listener_node:main",
+            "dummy_listener = dwm1001_driver.dummy_listener_node:main",
         ]
     },
 )


### PR DESCRIPTION
The listener and dummy_lister nodes now use the
geometry_msgs/PointStamped message to publish tag positions. The driver package no longer depends on the dwm1001_interfaces package.

There was a copy-paste bug in the setup.py console scripts section that used an old version of the dummy_listener from a separate dummy package.

Closes #13 