### PR TITLE
Update dummy listener to publish on tag ID

### DIFF
--- a/dwm1001_driver/dwm1001_driver/dummy_listener_node.py
+++ b/dwm1001_driver/dwm1001_driver/dummy_listener_node.py
@@ -33,7 +33,7 @@ class DummyListenerNode(Node):
 
         self.get_logger().info("Started position reporting.")
 
-        self.publisher = self.create_publisher(PointStamped, "tag_position", 1)
+        self.publisher = self.create_publisher(PointStamped, self.tag_id, 1)
         self.tf_broadcaster = TransformBroadcaster(self)
         self.timer = self.create_timer(1 / 10, self.timer_callback)
 


### PR DESCRIPTION
The dummy listener previously published on a hard-coded topic name.

Closes #19