### PR TITLE
Add Tag node and Dummy Tag node

### DIFF
--- a/dwm1001_driver/dwm1001_driver/dummy_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/dummy_tag_node.py
@@ -1,0 +1,90 @@
+# Copyright 2023 The Human and Intelligent Vehicle Ensembles (HIVE) Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+
+from tf2_ros import TransformBroadcaster
+
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+from geometry_msgs.msg import PointStamped, TransformStamped
+
+
+class DummyTagNode(Node):
+    def __init__(self) -> None:
+        super().__init__("dummy_tag")
+
+        self._declare_parameters()
+
+        self.tag_id = self.get_parameter("tag_id").value
+        if not self.tag_id:
+            self._shutdown_fatal("No DWM1001 tag identifier specified.")
+
+        self.get_logger().info("Started position reporting.")
+
+        self.publisher = self.create_publisher(PointStamped, self.tag_id, 1)
+        self.tf_broadcaster = TransformBroadcaster(self)
+        self.timer = self.create_timer(1 / 10, self.timer_callback)
+
+    def _shutdown_fatal(self, message: str) -> None:
+        self.get_logger().fatal(message + " Shutting down.")
+        exit()
+
+    def _declare_parameters(self):
+        tag_id = ParameterDescriptor(
+            description="DWM1001 tag identifier",
+            type=ParameterType.PARAMETER_STRING,
+            read_only=True,
+        )
+
+        self.declare_parameter("tag_id", "", tag_id)
+
+    def timer_callback(self):
+        time_stamp = self.get_clock().now().to_msg()
+
+        msg = PointStamped()
+
+        msg.header.stamp = time_stamp
+        msg.header.frame_id = self.tag_id
+
+        msg.point.x = 1.2
+        msg.point.y = 2.3
+        msg.point.z = 3.4
+
+        tf_msg = TransformStamped()
+
+        tf_msg.header.stamp = time_stamp
+        tf_msg.header.frame_id = "dwm1001"
+
+        tf_msg.child_frame_id = self.tag_id
+        tf_msg.transform.translation.x = 1.2
+        tf_msg.transform.translation.y = 2.3
+        tf_msg.transform.translation.z = 3.4
+
+        self.publisher.publish(msg)
+        self.tf_broadcaster.sendTransform(tf_msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    dummy_listener = DummyTagNode()
+    rclpy.spin(dummy_listener)
+
+    dummy_listener.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/dwm1001_driver/dwm1001_driver/tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/tag_node.py
@@ -1,0 +1,122 @@
+# Copyright 2023 The Human and Intelligent Vehicle Ensembles (HIVE) Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+
+from tf2_ros import TransformBroadcaster
+
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+from geometry_msgs.msg import PointStamped, TransformStamped
+
+import dwm1001
+import serial
+
+
+class TagNode(Node):
+    def __init__(self) -> None:
+        super().__init__("tag")
+
+        self._declare_parameters()
+
+        self.tag_id = self.get_parameter("tag_id").value
+        if not self.tag_id:
+            self._shutdown_fatal("No DWM1001 tag identifier specified.")
+
+        serial_handle = self._open_serial_port(self.get_parameter("serial_port").value)
+        self.dwm_handle = dwm1001.Tag(serial_handle)
+
+        self.dwm_handle.start_position_reporting()
+        self.get_logger().info("Started position reporting.")
+
+        self.point_publisher = self.create_publisher(PointStamped, self.tag_id, 1)
+        self.tf_broadcaster = TransformBroadcaster(self)
+        self.timer = self.create_timer(1 / 25, self.timer_callback)
+
+    def _open_serial_port(self, serial_port: str) -> serial.Serial:
+        if not serial_port:
+            self._shutdown_fatal("No serial port specified.")
+
+        try:
+            serial_handle = serial.Serial(serial_port, baudrate=115_200)
+        except serial.SerialException:
+            self._shutdown_fatal(f"Could not open serial port '{serial_port}'.")
+
+        self.get_logger().info(f"Opened serial port: '{serial_port}'.")
+
+        return serial_handle
+
+    def _shutdown_fatal(self, message: str) -> None:
+        self.get_logger().fatal(message + " Shutting down.")
+        exit()
+
+    def _declare_parameters(self):
+        serial_port_descriptor = ParameterDescriptor(
+            description="Device file or COM port associated with DWM1001",
+            type=ParameterType.PARAMETER_STRING,
+            read_only=True,
+        )
+        self.declare_parameter("serial_port", "", serial_port_descriptor)
+
+        tag_id_descriptor = ParameterDescriptor(
+            description="DWM1001 device identifier",
+            type=ParameterType.PARAMETER_STRING,
+            read_only=True,
+        )
+        self.declare_parameter("tag_id", "", tag_id_descriptor)
+
+    def timer_callback(self):
+        try:
+            tag_position = self.dwm_handle.position
+        except dwm1001.ParsingError:
+            self.get_logger().warn("Could not parse position report. Skipping it.")
+            return
+
+        time_stamp = self.get_clock().now().to_msg()
+
+        msg = PointStamped()
+
+        msg.header.stamp = time_stamp
+        msg.header.frame_id = self.tag_id
+
+        msg.point.x = tag_position.x_m
+        msg.point.y = tag_position.y_m
+        msg.point.z = tag_position.z_m
+
+        tf_msg = TransformStamped()
+
+        tf_msg.header.stamp = time_stamp
+        tf_msg.header.frame_id = "dwm1001"
+
+        tf_msg.child_frame_id = self.tag_id
+        tf_msg.transform.translation.x = tag_position.x_m
+        tf_msg.transform.translation.y = tag_position.y_m
+        tf_msg.transform.translation.z = tag_position.z_m
+
+        self.point_publisher.publish(msg)
+        self.tf_broadcaster.sendTransform(tf_msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    tag = TagNode()
+    rclpy.spin(tag)
+
+    tag.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/dwm1001_driver/setup.py
+++ b/dwm1001_driver/setup.py
@@ -21,6 +21,8 @@ setup(
         "console_scripts": [
             "listener = dwm1001_driver.listener_node:main",
             "dummy_listener = dwm1001_driver.dummy_listener_node:main",
+            "tag = dwm1001_driver.tag_node:main",
+            "dummy_tag = dwm1001_driver.dummy_tag_node:main",
         ]
     },
 )


### PR DESCRIPTION
The Tag node interfaces with a DWM1001 tag and publishes its current position. The Dummy Tag publishes hard-coded position data with an interface compatible with the real Tag node.

Closes #21 