### PR TITLE
Rename dwm1001_driver nodes

### DIFF
--- a/dwm1001_driver/README.md
+++ b/dwm1001_driver/README.md
@@ -4,10 +4,10 @@ This is a ROS 2 package for interfacing with the Qorvo (formerly Decawave) DWM10
 
 # Nodes
 
-## Listener Node (`listener`)
+## Passive Tag Node (`passive_tag`)
 
-This node connects to a DWM1001 configured as a passive anchor. It listens for position reports from tags and publishes
-any that it discovers.
+This node connects to a DWM1001 configured as a passive tag. It listens for position reports from active tags and
+publishes any that it discovers.
 
 ### Subscribers
 
@@ -17,7 +17,7 @@ This node does not provide subscribers.
 
 | Topic | Message Type | Frequency | Description |
 |-------|--------------|-----------|-------------|
-| `~/<discovered_tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | Discovered tag position. This node creates a publisher for each discovered DWM1001 tag, and the topic name is the tag's identifier. |
+| `~/<discovered_tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | Discovered active tag position. This node creates a publisher for each discovered DWM1001 active tag, and the topic name is the tag's identifier. |
 
 ### Parameters
 
@@ -34,9 +34,9 @@ This node does not provide services.
 This node does not provide actions.
 
 
-## Dummy Listener Node (`dummy_listener`)
+## Dummy Passive Tag Node (`dummy_passive_tag`)
 
-This node imitates the `listener` node by publishing a fixed position for a single tag.
+This node imitates the `passive_tag` node by publishing a fixed position for a single "discoverd" active tag.
 
 ### Subscribers
 
@@ -46,7 +46,65 @@ This node does not provide subscribers.
 
 | Topic | Message Type | Frequency | Description |
 |-------|--------------|-----------|-------------|
-| `~/<tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | Specified tag identifier from the node parameters. |
+| `~/<tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | "Discoverd" active tag's current position in the common DWM1001 coordinate frame. |
+
+### Parameters
+
+| Topic | Data Type | Default Value | Required | Read Only | Description |
+|-------|-----------|---------------|----------|-----------|-------------|
+| `~/tag_id` | `string` | `''` | Yes | Yes | Identifier for the imitated DWM1001 tag. |
+
+### Services
+
+This node does not provide services.
+
+### Actions
+
+This node does not provide actions.
+
+
+## Active Tag Node (`active_tag`)
+
+This node connects to a DWM1001 configured as an active tag and publishes its position.
+
+### Subscribers
+
+This node does not provide subscribers.
+
+### Publishers
+
+| Topic | Message Type | Frequency | Description |
+|-------|--------------|-----------|-------------|
+| `~/<tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | Tag's current position in the common DWM1001 coordinate frame. |
+
+### Parameters
+
+| Topic | Data Type | Default Value | Required | Read Only | Description |
+|-------|-----------|---------------|----------|-----------|-------------|
+| `~/serial_port` | `string` | `''` | Yes | Yes | Serial port for interfacing with the DWM1001 device. |
+
+### Services
+
+This node does not provide services.
+
+### Actions
+
+This node does not provide actions.
+
+
+## Dummy Passive Tag Node (`dummy_active_tag`)
+
+This node imitates the `active_tag` node by publishing a fixed position for the tag.
+
+### Subscribers
+
+This node does not provide subscribers.
+
+### Publishers
+
+| Topic | Message Type | Frequency | Description |
+|-------|--------------|-----------|-------------|
+| `~/<tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | Tag's current position in the common DWM1001 coordinate frame. |
 
 ### Parameters
 

--- a/dwm1001_driver/dwm1001_driver/active_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/active_tag_node.py
@@ -22,14 +22,14 @@ import dwm1001
 import serial
 
 
-class TagNode(Node):
+class ActiveTagNode(Node):
     def __init__(self) -> None:
-        super().__init__("tag")
+        super().__init__("active_tag")
 
         self._declare_parameters()
 
         serial_handle = self._open_serial_port(self.get_parameter("serial_port").value)
-        self.dwm_handle = dwm1001.Tag(serial_handle)
+        self.dwm_handle = dwm1001.ActiveTag(serial_handle)
 
         self.tag_id = "dw" + self.dwm_handle.tag_id
 
@@ -88,10 +88,10 @@ class TagNode(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    tag = TagNode()
-    rclpy.spin(tag)
+    active_tag = ActiveTagNode()
+    rclpy.spin(active_tag)
 
-    tag.destroy_node()
+    active_tag.destroy_node()
     rclpy.shutdown()
 
 

--- a/dwm1001_driver/dwm1001_driver/dummy_active_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/dummy_active_tag_node.py
@@ -19,9 +19,9 @@ from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 from geometry_msgs.msg import PointStamped, TransformStamped
 
 
-class DummyListenerNode(Node):
+class DummyActiveTagNode(Node):
     def __init__(self) -> None:
-        super().__init__("dummy_listener")
+        super().__init__("dummy_active_tag")
 
         self._declare_parameters()
 
@@ -65,10 +65,10 @@ class DummyListenerNode(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    dummy_listener = DummyListenerNode()
-    rclpy.spin(dummy_listener)
+    dummy_active_tag = DummyActiveTagNode()
+    rclpy.spin(dummy_active_tag)
 
-    dummy_listener.destroy_node()
+    dummy_active_tag.destroy_node()
     rclpy.shutdown()
 
 

--- a/dwm1001_driver/dwm1001_driver/dummy_passive_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/dummy_passive_tag_node.py
@@ -19,9 +19,9 @@ from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 from geometry_msgs.msg import PointStamped, TransformStamped
 
 
-class DummyTagNode(Node):
+class DummyPassiveTagNode(Node):
     def __init__(self) -> None:
-        super().__init__("dummy_tag")
+        super().__init__("dummy_passive_tag")
 
         self._declare_parameters()
 
@@ -65,10 +65,10 @@ class DummyTagNode(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    dummy_listener = DummyTagNode()
-    rclpy.spin(dummy_listener)
+    dummy_passive_tag = DummyPassiveTagNode()
+    rclpy.spin(dummy_passive_tag)
 
-    dummy_listener.destroy_node()
+    dummy_passive_tag.destroy_node()
     rclpy.shutdown()
 
 

--- a/dwm1001_driver/dwm1001_driver/passive_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/passive_tag_node.py
@@ -22,14 +22,14 @@ import dwm1001
 import serial
 
 
-class ListenerNode(Node):
+class PassiveTagNode(Node):
     def __init__(self) -> None:
-        super().__init__("listener")
+        super().__init__("passive_tag")
 
         self._declare_parameters()
 
         serial_handle = self._open_serial_port(self.get_parameter("serial_port").value)
-        self.dwm_handle = dwm1001.Listener(serial_handle)
+        self.dwm_handle = dwm1001.PassiveTag(serial_handle)
 
         self.dwm_handle.start_position_reporting()
         self.get_logger().info("Started position reporting.")
@@ -82,7 +82,7 @@ class ListenerNode(Node):
 
         if tag_id not in self.publishers_dict:
             self.get_logger().info(
-                f"Discovered new tag 'DW{tag_id}'. Creating publisher."
+                f"Discovered new active tag 'DW{tag_id}'. Creating publisher."
             )
 
             self.publishers_dict[tag_id] = self.create_publisher(
@@ -95,10 +95,10 @@ class ListenerNode(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    listener = ListenerNode()
-    rclpy.spin(listener)
+    passive_tag = PassiveTagNode()
+    rclpy.spin(passive_tag)
 
-    listener.destroy_node()
+    passive_tag.destroy_node()
     rclpy.shutdown()
 
 

--- a/dwm1001_driver/setup.py
+++ b/dwm1001_driver/setup.py
@@ -19,10 +19,10 @@ setup(
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
-            "listener = dwm1001_driver.listener_node:main",
-            "dummy_listener = dwm1001_driver.dummy_listener_node:main",
-            "tag = dwm1001_driver.tag_node:main",
-            "dummy_tag = dwm1001_driver.dummy_tag_node:main",
+            "passive_tag = dwm1001_driver.passive_tag_node:main",
+            "dummy_passive_tag = dwm1001_driver.dummy_passive_tag_node:main",
+            "active_tag = dwm1001_driver.active_tag_node:main",
+            "dummy_active_tag = dwm1001_driver.dummy_active_tag_node:main",
         ]
     },
 )


### PR DESCRIPTION
All references to Listener and listener have been changed to PassiveTag and passive_tag, respectively. All references to Tag and tag have been changed to ActiveTag and active_tag, respectively. The README.md file now has descriptions for the active_tag_node and dummy_active_tag_node.

Closes #33 