### PR TITLE
Add dynamic passive tag publishing frequency

### DIFF
--- a/dwm1001_driver/dwm1001_driver/passive_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/passive_tag_node.py
@@ -114,6 +114,10 @@ class PassiveTagNode(Node):
 
         self.publishers_dict[tag_id].publish(msg)
 
+        # DWM1001 tags publish at 10 Hz, so we want 2 times that
+        # (Nyquist theorem) per known tag.
+        self.timer.timer_period_ns = 1 / (20 * len(self.publishers_dict)) * 1e9
+
 
 def main(args=None):
     rclpy.init(args=args)


### PR DESCRIPTION
The PassiveTagNode now dynamically changes its publishing frequency based on the number of discovered tags. This change ensures each tag topic publishes at 10 Hz, the update frequency of the physical DWM1001s.

Closes #36 