### PR TITLE
Add dwm1001_transform package

### DIFF
--- a/dwm1001_transform/LICENSE
+++ b/dwm1001_transform/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/dwm1001_transform/README.md
+++ b/dwm1001_transform/README.md
@@ -1,0 +1,37 @@
+# DWM1001 Transform Package
+
+This is a ROS 2 package for transforming points from the `dwm1001` frame to the `map` frame. The package and its interfaces were inspired by the `navsat_transform_node` from the [`robot_localization`](https://index.ros.org/p/robot_localization/) package.
+
+# Nodes
+
+## DWM1001 Transform Node (`dwm1001_transform`)
+
+This node transforms incoming DWM1001 tag locations (`PointStamped` messages) from the common `dwm1001` frame to the `map` frame.
+
+### Subscribers
+
+| Topic | Message Type | Description |
+|-------|--------------|-------------|
+| `~/tag_position` | `geometry_msgs/PointStamped` | DWM1001 tag's position in the `dwm1001` frame. |
+| `~/tf` | `tf2_msgs/TFMessage` | Transform from the `dwm1001` frame to the `map` frame. |
+| `~/tf_static` | `tf2_msgs/TFMessage` | Transform from the `dwm1001` frame to the `map` frame. |
+
+**Note:** The transform between the `dwm1001` frame and the `map` frame can be static or dynamic as long as it's provided.
+
+### Publishers
+
+| Topic | Message Type | Frequency | Description |
+|-------|--------------|-----------|-------------|
+| `~/odometry/ips` | `nav_msgs/Odometry` | Event-driven | DWM1001 tag's position transformed to the `map` frame. The following message fields are unused: `child_frame_id`, `pose.pose.orientation`, and `twist`. |
+
+### Parameters
+
+This node does not provide parameters.
+
+### Services
+
+This node does not provide services.
+
+### Actions
+
+This node does not provide actions.

--- a/dwm1001_transform/dwm1001_transform/__init__.py
+++ b/dwm1001_transform/dwm1001_transform/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 The Human and Intelligent Vehicle Ensembles (HIVE) Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/dwm1001_transform/dwm1001_transform/dwm1001_transform_node.py
+++ b/dwm1001_transform/dwm1001_transform/dwm1001_transform_node.py
@@ -1,0 +1,123 @@
+# Copyright 2023 The Human and Intelligent Vehicle Ensembles (HIVE) Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+
+from geometry_msgs.msg import Point, PointStamped, Quaternion, Transform, Vector3
+from nav_msgs.msg import Odometry
+
+from tf2_ros import TransformException
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_listener import TransformListener
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+
+def quaternion_msg_to_rotation_matrix(quaternion: Quaternion) -> np.ndarray:
+    quat = np.array(
+        [
+            quaternion.x,
+            quaternion.y,
+            quaternion.z,
+            quaternion.w,
+        ]
+    )
+
+    return Rotation.from_quat(quat).as_matrix()
+
+
+def vector3_msg_to_vector(vector3: Vector3) -> np.ndarray:
+    return np.asarray(
+        [
+            [vector3.x],
+            [vector3.y],
+            [vector3.z],
+        ]
+    )
+
+
+def point_msg_to_augmented_vector(point: Point) -> np.ndarray:
+    return np.array([[point.x], [point.y], [point.z], [1]])
+
+
+def augmented_vector_to_point_msg(vector: np.ndarray) -> Point:
+    point = Point()
+
+    point.x = vector[0, 0]
+    point.y = vector[1, 0]
+    point.z = vector[2, 0]
+
+    return point
+
+
+def transform_msg_to_matrix(transform: Transform) -> np.ndarray:
+    rotation_matrix = quaternion_msg_to_rotation_matrix(transform.rotation)
+    translation_vector = vector3_msg_to_vector(transform.translation)
+
+    transform_matrix = np.hstack([rotation_matrix, translation_vector])
+    transform_matrix = np.vstack([transform_matrix, np.array([0, 0, 0, 1])])
+
+    return transform_matrix
+
+
+class Dwm1001TransformNode(Node):
+    def __init__(self) -> None:
+        super().__init__("dwm1001_transform")
+
+        self.tag_position_sub = self.create_subscription(
+            PointStamped, "tag_position", self._tag_position_callback, 1
+        )
+        self.odom_pub = self.create_publisher(Odometry, "odometry/ips", 1)
+
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self)
+
+    def _tag_position_callback(self, msg: PointStamped) -> None:
+        try:
+            transform = self.tf_buffer.lookup_transform(
+                "map", "dwm1001", rclpy.time.Time()
+            )
+        except TransformException:
+            self.get_logger().error(
+                "Could not transform from 'dwm1001' to 'map'. Skipping transform."
+            )
+            return
+
+        transform_matrix = transform_msg_to_matrix(transform.transform)
+        dwm1001_point = point_msg_to_augmented_vector(msg.point)
+        map_point = transform_matrix @ dwm1001_point
+
+        map_odom = Odometry()
+        map_odom.header.stamp = self.get_clock().now().to_msg()
+        map_odom.header.frame_id = "map"
+        map_odom.pose.pose.position = augmented_vector_to_point_msg(map_point)
+        map_odom.twist.covariance[0] = -1
+
+        self.odom_pub.publish(map_odom)
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+
+    dwm1001_transform = Dwm1001TransformNode()
+    rclpy.spin(dwm1001_transform)
+
+    dwm1001_transform.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/dwm1001_transform/package.xml
+++ b/dwm1001_transform/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dwm1001_transform</name>
+  <version>0.1.0</version>
+  <description>ROS 2 package for transforming points from the dwm1001 frame to the map frame</description>
+  <maintainer email="morrissettal2@vcu.edu">Adam Morrissett</maintainer>
+  <license>Apache License 2.0</license>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/dwm1001_transform/setup.cfg
+++ b/dwm1001_transform/setup.cfg
@@ -1,0 +1,5 @@
+[develop]
+script_dir=$base/lib/dwm1001_transform
+
+[install]
+install_scripts=$base/lib/dwm1001_transform

--- a/dwm1001_transform/setup.py
+++ b/dwm1001_transform/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+package_name = "dwm1001_transform"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=[package_name],
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Adam Morrissett",
+    maintainer_email="morrissettal2@vcu.edu",
+    description="ROS 2 package for transforming points from the dwm1001 frame to the map frame",
+    license="Apache License 2.0",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "dwm1001_transform = dwm1001_transform.dwm1001_transform_node:main"
+        ],
+    },
+)


### PR DESCRIPTION
This package transforms DWM1001 tag positions from the common DWM1001 reference frame to the map frame. Right now, the frames are hardcoded, but future work should turn those into parameters.

Closes #39 