### PR TITLE
Update pydwm1001 for dwm1001_driver

### DIFF
--- a/dwm1001_driver/README.md
+++ b/dwm1001_driver/README.md
@@ -17,7 +17,7 @@ This node does not provide subscribers.
 
 | Topic | Message Type | Frequency | Description |
 |-------|--------------|-----------|-------------|
-| `~/<discovered_tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | Discovered active tag position. This node creates a publisher for each discovered DWM1001 active tag, and the topic name is the tag's identifier. |
+| `~/<discovered_tag_label>` | `geometry_msgs/PointStamped` | 10 Hz | Discovered active tag position. This node creates a publisher for each discovered DWM1001 active tag, and the topic name is the tag's label. |
 
 ### Parameters
 
@@ -46,13 +46,13 @@ This node does not provide subscribers.
 
 | Topic | Message Type | Frequency | Description |
 |-------|--------------|-----------|-------------|
-| `~/<tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | "Discoverd" active tag's current position in the common DWM1001 coordinate frame. |
+| `~/<tag_label>` | `geometry_msgs/PointStamped` | 10 Hz | "Discoverd" active tag's current position in the common DWM1001 coordinate frame. |
 
 ### Parameters
 
 | Topic | Data Type | Default Value | Required | Read Only | Description |
 |-------|-----------|---------------|----------|-----------|-------------|
-| `~/tag_id` | `string` | `''` | Yes | Yes | Identifier for the imitated DWM1001 tag. |
+| `~/tag_label` | `string` | `''` | Yes | Yes | Label for the imitated DWM1001 tag. |
 
 ### Services
 
@@ -75,7 +75,7 @@ This node does not provide subscribers.
 
 | Topic | Message Type | Frequency | Description |
 |-------|--------------|-----------|-------------|
-| `~/<tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | Tag's current position in the common DWM1001 coordinate frame. |
+| `~/<tag_label>` | `geometry_msgs/PointStamped` | 10 Hz | Tag's current position in the common DWM1001 coordinate frame. |
 
 ### Parameters
 
@@ -105,13 +105,13 @@ This node does not provide subscribers.
 
 | Topic | Message Type | Frequency | Description |
 |-------|--------------|-----------|-------------|
-| `~/<tag_id>` | `geometry_msgs/PointStamped` | 10 Hz | Tag's current position in the common DWM1001 coordinate frame. |
+| `~/<tag_label>` | `geometry_msgs/PointStamped` | 10 Hz | Tag's current position in the common DWM1001 coordinate frame. |
 
 ### Parameters
 
 | Topic | Data Type | Default Value | Required | Read Only | Description |
 |-------|-----------|---------------|----------|-----------|-------------|
-| `~/tag_id` | `string` | `''` | Yes | Yes | Identifier for the imitated DWM1001 tag. |
+| `~/tag_label` | `string` | `''` | Yes | Yes | Label for the imitated DWM1001 tag. |
 
 ### Services
 

--- a/dwm1001_driver/dwm1001_driver/active_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/active_tag_node.py
@@ -31,12 +31,12 @@ class ActiveTagNode(Node):
         serial_handle = self._open_serial_port(self.get_parameter("serial_port").value)
         self.dwm_handle = dwm1001.ActiveTag(serial_handle)
 
-        self.tag_id = "dw" + self.dwm_handle.tag_id
+        self.tag_label = self.dwm_handle.system_info.label
 
         self.dwm_handle.start_position_reporting()
         self.get_logger().info("Started position reporting.")
 
-        self.point_publisher = self.create_publisher(PointStamped, self.tag_id, 1)
+        self.point_publisher = self.create_publisher(PointStamped, self.tag_label, 1)
         self.timer = self.create_timer(1 / 25, self.timer_callback)
 
     def _open_serial_port(self, serial_port: str) -> serial.Serial:

--- a/dwm1001_driver/dwm1001_driver/dummy_active_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/dummy_active_tag_node.py
@@ -25,13 +25,13 @@ class DummyActiveTagNode(Node):
 
         self._declare_parameters()
 
-        self.tag_id = self.get_parameter("tag_id").value
-        if not self.tag_id:
-            self._shutdown_fatal("No DWM1001 tag identifier specified.")
+        self.tag_label = self.get_parameter("tag_label").value
+        if not self.tag_label:
+            self._shutdown_fatal("No DWM1001 tag label specified.")
 
         self.get_logger().info("Started position reporting.")
 
-        self.publisher = self.create_publisher(PointStamped, self.tag_id, 1)
+        self.publisher = self.create_publisher(PointStamped, self.tag_label, 1)
         self.timer = self.create_timer(1 / 10, self.timer_callback)
 
     def _shutdown_fatal(self, message: str) -> None:
@@ -39,13 +39,13 @@ class DummyActiveTagNode(Node):
         exit()
 
     def _declare_parameters(self):
-        tag_id = ParameterDescriptor(
-            description="DWM1001 tag identifier",
+        tag_label = ParameterDescriptor(
+            description="DWM1001 tag label",
             type=ParameterType.PARAMETER_STRING,
             read_only=True,
         )
 
-        self.declare_parameter("tag_id", "", tag_id)
+        self.declare_parameter("tag_label", "", tag_label)
 
     def timer_callback(self):
         time_stamp = self.get_clock().now().to_msg()

--- a/dwm1001_driver/dwm1001_driver/dummy_passive_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/dummy_passive_tag_node.py
@@ -25,13 +25,13 @@ class DummyPassiveTagNode(Node):
 
         self._declare_parameters()
 
-        self.tag_id = self.get_parameter("tag_id").value
-        if not self.tag_id:
-            self._shutdown_fatal("No DWM1001 tag identifier specified.")
+        self.tag_label = self.get_parameter("tag_label").value
+        if not self.tag_label:
+            self._shutdown_fatal("No DWM1001 tag label specified.")
 
         self.get_logger().info("Started position reporting.")
 
-        self.publisher = self.create_publisher(PointStamped, self.tag_id, 1)
+        self.publisher = self.create_publisher(PointStamped, self.tag_label, 1)
         self.timer = self.create_timer(1 / 10, self.timer_callback)
 
     def _shutdown_fatal(self, message: str) -> None:
@@ -39,13 +39,13 @@ class DummyPassiveTagNode(Node):
         exit()
 
     def _declare_parameters(self):
-        tag_id = ParameterDescriptor(
-            description="DWM1001 tag identifier",
+        tag_label = ParameterDescriptor(
+            description="DWM1001 tag label",
             type=ParameterType.PARAMETER_STRING,
             read_only=True,
         )
 
-        self.declare_parameter("tag_id", "", tag_id)
+        self.declare_parameter("tag_label", "", tag_label)
 
     def timer_callback(self):
         time_stamp = self.get_clock().now().to_msg()

--- a/dwm1001_driver/dwm1001_driver/passive_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/passive_tag_node.py
@@ -76,7 +76,7 @@ class PassiveTagNode(Node):
         ignore_tags_descriptor = ParameterDescriptor(
             description="DWM1001 tags to ignore. This node will not publish "
             + "position reports coming from these tags. Expected format is "
-            + " comma-separated values. Example: 'DW1234,DW1235,DW1236'.",
+            + "comma-separated values. Example: 'DW1234,DW1235,DW1236'.",
             type=ParameterType.PARAMETER_STRING,
             read_only=True,
         )
@@ -84,12 +84,12 @@ class PassiveTagNode(Node):
 
     def timer_callback(self):
         try:
-            tag_id, tag_position = self.dwm_handle.wait_for_position_report()
+            tag_label, tag_position = self.dwm_handle.wait_for_position_report()
         except dwm1001.ParsingError:
             self.get_logger().warn("Could not parse position report. Skipping it.")
             return
 
-        if "DW" + tag_id in self.tags_to_ignore:
+        if tag_label in self.tags_to_ignore:
             return
 
         time_stamp = self.get_clock().now().to_msg()
@@ -103,16 +103,16 @@ class PassiveTagNode(Node):
         msg.point.y = tag_position.y_m
         msg.point.z = tag_position.z_m
 
-        if tag_id not in self.publishers_dict:
+        if tag_label not in self.publishers_dict:
             self.get_logger().info(
-                f"Discovered new active tag 'DW{tag_id}'. Creating publisher."
+                f"Discovered new active tag '{tag_label}'. Creating publisher."
             )
 
-            self.publishers_dict[tag_id] = self.create_publisher(
-                PointStamped, "dw" + tag_id, 1
+            self.publishers_dict[tag_label] = self.create_publisher(
+                PointStamped, tag_label, 1
             )
 
-        self.publishers_dict[tag_id].publish(msg)
+        self.publishers_dict[tag_label].publish(msg)
 
         # DWM1001 tags publish at 10 Hz, so we want 2 times that
         # (Nyquist theorem) per known tag.


### PR DESCRIPTION
The `dwm1001_driver` package now uses the latest version of `pydwm1001`. Node parameter and variable names have been renamed from `tag_id` to `tag_label` to follow pydwm1001's new terminology.

Closes #41