### PR TITLE
Changed launch file to use config files

### DIFF
--- a/dwm1001_driver/dwm1001_driver/active_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/active_tag_node.py
@@ -28,7 +28,10 @@ class ActiveTagNode(Node):
 
         self._declare_parameters()
 
-        serial_handle = self._open_serial_port(self.get_parameter("serial_port").value)
+        serial_port_param = self.get_parameter("serial_port").value
+        self.get_logger().info(f"Provided serial port: '{serial_port_param}'")
+
+        serial_handle = self._open_serial_port(serial_port_param)
         self.dwm_handle = dwm1001.ActiveTag(serial_handle)
 
         self.tag_label = self.dwm_handle.system_info.label

--- a/dwm1001_launch/CMakeLists.txt
+++ b/dwm1001_launch/CMakeLists.txt
@@ -22,6 +22,9 @@ include(GNUInstallDirs)
 install(DIRECTORY launch
   DESTINATION ${CMAKE_INSTALL_DATADIR}/dwm1001_launch
 )
+install(DIRECTORY config
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/dwm1001_launch
+)
 
 #install(DIRECTORY params
 #  DESTINATION ${CMAKE_INSTALL_DATADIR}/dwm1001_launch

--- a/dwm1001_launch/README.md
+++ b/dwm1001_launch/README.md
@@ -10,4 +10,9 @@ Currently, we have two lauch files:
 
 ## Parameter Files
 
-TBD
+All parameter files should be contained in the `config` directory.
+At this time, if you want to make a custom deployment, you need to create a new `yaml` file that has your desired namespace instead of `default`.
+Then, you invoke your launch file with
+```
+ros2 launch active_node.launch.py tag_namespace:=<custome name> config_file:=<custom config yaml>
+```

--- a/dwm1001_launch/README.md
+++ b/dwm1001_launch/README.md
@@ -14,5 +14,5 @@ All parameter files should be contained in the `config` directory.
 At this time, if you want to make a custom deployment, you need to create a new `yaml` file that has your desired namespace instead of `default`.
 Then, you invoke your launch file with
 ```
-ros2 launch active_node.launch.py tag_namespace:=<custome name> config_file:=<custom config yaml>
+ros2 launch active_node.launch.py tag_namespace:=<custom name> config_file:=<custom config yaml>
 ```

--- a/dwm1001_launch/config/default_active.yaml
+++ b/dwm1001_launch/config/default_active.yaml
@@ -1,0 +1,3 @@
+active_tag:
+  ros__parameters:
+    serial_port: "/dev/ttyACM0"

--- a/dwm1001_launch/config/default_active.yaml
+++ b/dwm1001_launch/config/default_active.yaml
@@ -1,3 +1,4 @@
-active_tag:
-  ros__parameters:
-    serial_port: "/dev/ttyACM0"
+active:
+  active_tag:
+    ros__parameters:
+      serial_port: "/dev/ttyACM0"

--- a/dwm1001_launch/config/default_passive.yaml
+++ b/dwm1001_launch/config/default_passive.yaml
@@ -1,0 +1,5 @@
+passive:
+  passive_tag:
+    ros__parameters:
+      serial_port: "/dev/ttyACM1"
+      ignore_tags: ""

--- a/dwm1001_launch/launch/active_node.launch.py
+++ b/dwm1001_launch/launch/active_node.launch.py
@@ -36,6 +36,13 @@ from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description() -> LaunchDescription:
 
+    tag_namespace_val = LaunchConfiguration('tag_namespace')
+    tag_namespace_arg = DeclareLaunchArgument(
+            'tag_namespace',
+            default_value=TextSubstitution(text='active'),
+            description='Name of the tag namespace'
+        )
+
     config_file_val = LaunchConfiguration('config_file')
     # TODO: figure out the defaults here - why does it require config_file? This default should work.
     default_config_file_path = PathJoinSubstitution([FindPackageShare('dwm1001_launch'),
@@ -50,7 +57,7 @@ def generate_launch_description() -> LaunchDescription:
     dwm1001_driver = Node(
         package="dwm1001_driver",
         executable="active_tag",
-        # name="dw5188_tag",
+        namespace=tag_namespace_val,
         parameters=[PathJoinSubstitution([FindPackageShare('dwm1001_launch'), 'config', config_file_val])]
     )
 
@@ -85,5 +92,5 @@ def generate_launch_description() -> LaunchDescription:
     # )
 
     return LaunchDescription(
-        [dwm1001_driver, config_file_launch_arg] #map_to_dwm1001_transform, anchor_visualizer, dwm_transform]
+        [tag_namespace_arg, config_file_launch_arg, dwm1001_driver] #map_to_dwm1001_transform, anchor_visualizer, dwm_transform]
     )

--- a/dwm1001_launch/launch/active_node.launch.py
+++ b/dwm1001_launch/launch/active_node.launch.py
@@ -61,15 +61,22 @@ def generate_launch_description() -> LaunchDescription:
         parameters=[PathJoinSubstitution([FindPackageShare('dwm1001_launch'), 'config', config_file_val])]
     )
 
-    # map_to_dwm1001_transform = Node(
-    #     package="tf2_ros",
-    #     executable="static_transform_publisher",
-    #     name="map_to_dwm1001_broadcaster",
-    #     # x, y, z, roll, pitch, yaw, frame_id, child_frame_id
-    #     # arguments=["2.1336", "0", "0", "0", "0", "0", "map", "dwm1001"],
-    #     arguments=["0", "0.95", "1.8", "0", "0", "0", "map", "dwm1001"],
+    map_to_dwm1001_transform = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="map_to_dwm1001_broadcaster",
+        # x, y, z, roll, pitch, yaw, frame_id, child_frame_id
+        arguments=["2.49", "0.0", "1.9", "0", "0", "0", "map", "dwm1001"],
+    )
+
+    # dwm_transform = Node(
+    #     package="dwm1001_transform",
+    #     executable="dwm1001_transform",
+    #     name="dwm1001_transform",
+    #     remappings=[("tag_position", "DW0414")],
     # )
 
+    # TODO: Revisit the anchor_visualizer launch
     # anchor_visualizer = Node(
     #     package="dwm1001_visualization",
     #     executable="anchor_visualizer",
@@ -84,13 +91,6 @@ def generate_launch_description() -> LaunchDescription:
     #     ],
     # )
 
-    # dwm_transform = Node(
-    #     package="dwm1001_transform",
-    #     executable="dwm1001_transform",
-    #     name="dwm1001_transform",
-    #     remappings=[("tag_position", "DW0414")],
-    # )
-
     return LaunchDescription(
-        [tag_namespace_arg, config_file_launch_arg, dwm1001_driver] #map_to_dwm1001_transform, anchor_visualizer, dwm_transform]
+        [tag_namespace_arg, config_file_launch_arg, dwm1001_driver, map_to_dwm1001_transform] #dwm_transform]
     )

--- a/dwm1001_launch/launch/active_node.launch.py
+++ b/dwm1001_launch/launch/active_node.launch.py
@@ -28,14 +28,30 @@
 
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, TextSubstitution, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description() -> LaunchDescription:
+
+    config_file_val = LaunchConfiguration('config_file')
+    # TODO: figure out the defaults here - why does it require config_file? This default should work.
+    default_config_file_path = PathJoinSubstitution([FindPackageShare('dwm1001_launch'),
+                                                     'config',
+                                                     'default_active.yaml'])
+    config_file_launch_arg = DeclareLaunchArgument(
+        'config_file',
+        default_value=default_config_file_path,
+        description='Configuration file for the active node'
+    )
+
     dwm1001_driver = Node(
         package="dwm1001_driver",
         executable="active_tag",
-        name="dw5188_tag",
-        parameters=[{"serial_port": "/dev/ttyACM0"}],
+        # name="dw5188_tag",
+        parameters=[PathJoinSubstitution([FindPackageShare('dwm1001_launch'), 'config', config_file_val])]
     )
 
     # map_to_dwm1001_transform = Node(
@@ -69,5 +85,5 @@ def generate_launch_description() -> LaunchDescription:
     # )
 
     return LaunchDescription(
-        [dwm1001_driver] #map_to_dwm1001_transform, anchor_visualizer, dwm_transform]
+        [dwm1001_driver, config_file_launch_arg] #map_to_dwm1001_transform, anchor_visualizer, dwm_transform]
     )

--- a/dwm1001_launch/launch/active_node.launch.py
+++ b/dwm1001_launch/launch/active_node.launch.py
@@ -44,7 +44,6 @@ def generate_launch_description() -> LaunchDescription:
         )
 
     config_file_val = LaunchConfiguration('config_file')
-    # TODO: figure out the defaults here - why does it require config_file? This default should work.
     default_config_file_path = PathJoinSubstitution([FindPackageShare('dwm1001_launch'),
                                                      'config',
                                                      'default_active.yaml'])
@@ -61,36 +60,6 @@ def generate_launch_description() -> LaunchDescription:
         parameters=[PathJoinSubstitution([FindPackageShare('dwm1001_launch'), 'config', config_file_val])]
     )
 
-    map_to_dwm1001_transform = Node(
-        package="tf2_ros",
-        executable="static_transform_publisher",
-        name="map_to_dwm1001_broadcaster",
-        # x, y, z, roll, pitch, yaw, frame_id, child_frame_id
-        arguments=["2.49", "0.0", "1.9", "0", "0", "0", "map", "dwm1001"],
-    )
-
-    # dwm_transform = Node(
-    #     package="dwm1001_transform",
-    #     executable="dwm1001_transform",
-    #     name="dwm1001_transform",
-    #     remappings=[("tag_position", "DW0414")],
-    # )
-
-    # TODO: Revisit the anchor_visualizer launch
-    # anchor_visualizer = Node(
-    #     package="dwm1001_visualization",
-    #     executable="anchor_visualizer",
-    #     name="anchor_visualizer",
-    #     parameters=[
-    #         {
-    #             "initiator_anchor_position": "0.0,0.0,1.8",
-    #             "anchor_positions": "0.0,5.02,1.8;4.98,5.96,1.8;9.55,4.85,1.82;9.55,0.84,1.82",
-    #             # "initiator_anchor_position": "0.00,0.00,1.03",
-    #             # "anchor_positions": "-2.13,2.13,0.94;2.74,1.52,1.04;0.61,3.05,1.02",
-    #         }
-    #     ],
-    # )
-
     return LaunchDescription(
-        [tag_namespace_arg, config_file_launch_arg, dwm1001_driver, map_to_dwm1001_transform] #dwm_transform]
+        [tag_namespace_arg, config_file_launch_arg, dwm1001_driver]
     )

--- a/dwm1001_launch/launch/passive_node.launch.py
+++ b/dwm1001_launch/launch/passive_node.launch.py
@@ -30,7 +30,6 @@ def generate_launch_description() -> LaunchDescription:
         )
     
     config_file_val = LaunchConfiguration('config_file')
-    # TODO: figure out the defaults here - why does it require config_file? This default should work.
     default_config_file_path = PathJoinSubstitution([FindPackageShare('dwm1001_launch'),
                                                      'config',
                                                      'default_passive.yaml'])

--- a/dwm1001_launch/launch/passive_node.launch.py
+++ b/dwm1001_launch/launch/passive_node.launch.py
@@ -47,5 +47,5 @@ def generate_launch_description() -> LaunchDescription:
     )
 
     return LaunchDescription(
-        [tag_namespace_arg, dwm1001_driver]
+        [tag_namespace_arg, config_file_launch_arg, dwm1001_driver]
     )

--- a/dwm1001_launch/launch/passive_node.launch.py
+++ b/dwm1001_launch/launch/passive_node.launch.py
@@ -14,16 +14,39 @@
 
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, TextSubstitution, PathJoinSubstitution, EnvironmentVariable
+from launch_ros.substitutions import FindPackageShare
+from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description() -> LaunchDescription:
+
+    tag_namespace_val = LaunchConfiguration('tag_namespace')
+    tag_namespace_arg = DeclareLaunchArgument(
+            'tag_namespace',
+            default_value=TextSubstitution(text='passive'),
+            description='Name of the tag namespace'
+        )
+    
+    config_file_val = LaunchConfiguration('config_file')
+    # TODO: figure out the defaults here - why does it require config_file? This default should work.
+    default_config_file_path = PathJoinSubstitution([FindPackageShare('dwm1001_launch'),
+                                                     'config',
+                                                     'default_passive.yaml'])
+    config_file_launch_arg = DeclareLaunchArgument(
+        'config_file',
+        default_value=default_config_file_path,
+        description='Configuration file for the active node'
+    )
+
     dwm1001_driver = Node(
         package="dwm1001_driver",
         executable="passive_tag",
-        name="dw1729_tag",
-        parameters=[{"serial_port": "/dev/ttyACM0"}],
+        namespace=tag_namespace_val,
+        parameters=[PathJoinSubstitution([FindPackageShare('dwm1001_launch'), 'config', config_file_val])],
     )
 
     return LaunchDescription(
-        [dwm1001_driver]
+        [tag_namespace_arg, dwm1001_driver]
     )


### PR DESCRIPTION
The active and passive nodes now accept configuration files in their launch files. Resolves #45.