### PR TITLE
Revised topic naming convention

### DIFF
--- a/dwm1001_driver/dwm1001_driver/active_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/active_tag_node.py
@@ -34,12 +34,11 @@ class ActiveTagNode(Node):
         serial_handle = self._open_serial_port(serial_port_param)
         self.dwm_handle = dwm1001.ActiveTag(serial_handle)
 
-        self.tag_label = self.dwm_handle.system_info.label
-
         self.dwm_handle.start_position_reporting()
         self.get_logger().info("Started position reporting.")
 
-        self.point_publisher = self.create_publisher(PointStamped, self.tag_label, 1)
+        tag_topic = 'output/' + self.get_parameter('tag_id').value
+        self.point_publisher = self.create_publisher(PointStamped, tag_topic, 1)
         self.timer = self.create_timer(1 / 25, self.timer_callback)
 
     def _open_serial_port(self, serial_port: str) -> serial.Serial:
@@ -65,7 +64,13 @@ class ActiveTagNode(Node):
             type=ParameterType.PARAMETER_STRING,
             read_only=True,
         )
+        tag_id_descriptor = ParameterDescriptor(
+            description="The ID for the particular DWM1001 device.",
+            type=ParameterType.PARAMETER_STRING,
+            read_only=True,
+        )
         self.declare_parameter("serial_port", "", serial_port_descriptor)
+        self.declare_parameter("tag_id", "", tag_id_descriptor)
 
     def timer_callback(self):
         try:

--- a/dwm1001_driver/dwm1001_driver/active_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/active_tag_node.py
@@ -37,7 +37,7 @@ class ActiveTagNode(Node):
         self.dwm_handle.start_position_reporting()
         self.get_logger().info("Started position reporting.")
 
-        tag_topic = 'output/' + self.get_parameter('tag_id').value
+        tag_topic = f"output/{self.get_parameter('tag_id').value}"
         self.point_publisher = self.create_publisher(PointStamped, tag_topic, 1)
         self.timer = self.create_timer(1 / 25, self.timer_callback)
 

--- a/dwm1001_driver/dwm1001_driver/passive_tag_node.py
+++ b/dwm1001_driver/dwm1001_driver/passive_tag_node.py
@@ -108,8 +108,9 @@ class PassiveTagNode(Node):
                 f"Discovered new active tag '{tag_label}'. Creating publisher."
             )
 
+            tag_topic = f'output/{tag_label}'
             self.publishers_dict[tag_label] = self.create_publisher(
-                PointStamped, tag_label, 1
+                PointStamped, tag_topic, 1
             )
 
         self.publishers_dict[tag_label].publish(msg)

--- a/dwm1001_launch/config/default_active.yaml
+++ b/dwm1001_launch/config/default_active.yaml
@@ -2,3 +2,4 @@ active:
   active_tag:
     ros__parameters:
       serial_port: "/dev/ttyACM0"
+      tag_id: "DW5188"


### PR DESCRIPTION
Updated the desired naming convention for the dwm1001 active and passive tags to use `output/tag_id`.